### PR TITLE
testing cognito addition to take notes api

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -268,7 +268,7 @@ Outputs:
     Value: !Ref UserPool
   CognitoClientID:
     Description: The Cognito UserPool Client ID
-    Value: !Ref UserPoolTokenClient
+    Value: !Ref UserPoolClient
   CognitoDomainName:
     Description: The Cognito Hosted UI Domain Name
     Value: !Join

--- a/template.yaml
+++ b/template.yaml
@@ -237,18 +237,17 @@ Resources:
       GenerateSecret: false
       AllowedOAuthFlowsUserPoolClient: true
       AllowedOAuthFlows:
-        - code
         - implicit
       CallbackURLs:
-        - http://localhost:3000
-        - http://localhost:8080
-        - https://localhost
+        - http://localhost:3000/
       SupportedIdentityProviders:
         - COGNITO
       AllowedOAuthScopes:
         - phone
         - email
         - openid
+        - profile
+        - aws.cognito.signin.user.admin
       ExplicitAuthFlows:
         - USER_PASSWORD_AUTH
   UserPoolDomain:

--- a/template.yaml
+++ b/template.yaml
@@ -240,12 +240,6 @@ Resources:
         - http://localhost:3000
         - http://localhost:8080
         - https://localhost
-        - !Join
-          - ''
-          - - https://
-            - !GetAtt AmplifyBranch.BranchName
-            - .
-            - !GetAtt AmplifyApp.DefaultDomain
       SupportedIdentityProviders:
         - COGNITO
       AllowedOAuthScopes:

--- a/template.yaml
+++ b/template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: TakeNotes serverless web application
 Globals:
@@ -33,7 +33,7 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Join
-        - "-"
+        - '-'
         - - TakeNotes-table-test
           - !Ref AWS::StackName
       KeySchema:
@@ -52,7 +52,7 @@ Resources:
     MethodSettings:
       DataTraceEnabled: true
       MetricsEnabled: true
-      HttpMethod: "*"
+      HttpMethod: '*'
       ResourcePath: !Sub ${VersionParam}/*
       LoggingLevel: INFO
     AccessLogSetting:
@@ -63,9 +63,13 @@ Resources:
       StageName: !Ref StageNameParam
       TracingEnabled: true
       Cors:
-        AllowOrigin: "'*'"
-        AllowMethods: "'OPTIONS,HEAD,GET,PUT,POST,DELETE'"
-        AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+        AllowOrigin: '''*'''
+        AllowMethods: '''OPTIONS,HEAD,GET,PUT,POST,DELETE'''
+        AllowHeaders: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'''
+      Auth:
+        Authorizers:
+          CognitoAuthorizer:
+            UserPoolArn: !GetAtt UserPool.Arn
   GetTakeNotesUser:
     Type: AWS::Serverless::Function
     Properties:
@@ -79,9 +83,9 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref TakeNotesTable
-          AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
-          USE_DYNAMODB_LOCAL: "0"
-          DYNAMODB_LOCAL_URI: ""
+          AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
+          USE_DYNAMODB_LOCAL: '0'
+          DYNAMODB_LOCAL_URI: ''
       Events:
         GetUser:
           Type: Api
@@ -89,6 +93,8 @@ Resources:
             Path: /users/{id}
             Method: get
             RestApiId: !Ref TakeNotesApi
+            Auth:
+              Authorizer: CognitoAuthorizer
   PostTakeNotesUser:
     Type: AWS::Serverless::Function
     Properties:
@@ -102,8 +108,8 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref TakeNotesTable
-          AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
-          ENDPOINT_OVERRIDE: ""
+          AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
+          ENDPOINT_OVERRIDE: ''
       Events:
         PostUser:
           Type: Api
@@ -111,6 +117,8 @@ Resources:
             Path: /users/
             Method: POST
             RestApiId: !Ref TakeNotesApi
+            Auth:
+              Authorizer: CognitoAuthorizer
   PutTakeNotesUser:
     Type: AWS::Serverless::Function
     Properties:
@@ -124,8 +132,8 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref TakeNotesTable
-          AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
-          ENDPOINT_OVERRIDE: ""
+          AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
+          ENDPOINT_OVERRIDE: ''
       Events:
         PutUser:
           Type: Api
@@ -133,6 +141,8 @@ Resources:
             Path: /users/{id}
             Method: PUT
             RestApiId: !Ref TakeNotesApi
+            Auth:
+              Authorizer: CognitoAuthorizer
   DeleteTakeNotesUser:
     Type: AWS::Serverless::Function
     Properties:
@@ -146,8 +156,8 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref TakeNotesTable
-          AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
-          ENDPOINT_OVERRIDE: ""
+          AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
+          ENDPOINT_OVERRIDE: ''
       Events:
         DeleteUser:
           Type: Api
@@ -155,6 +165,8 @@ Resources:
             Path: /users/{id}
             Method: DELETE
             RestApiId: !Ref TakeNotesApi
+            Auth:
+              Authorizer: CognitoAuthorizer
   TakeNotesTestRequestGet:
     Type: AWS::Serverless::Function
     Properties:
@@ -168,8 +180,8 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref TakeNotesTable
-          AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
-          ENDPOINT_OVERRIDE: ""
+          AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
+          ENDPOINT_OVERRIDE: ''
       Events:
         TestReq:
           Type: Api
@@ -177,12 +189,14 @@ Resources:
             Path: /
             Method: ANY
             RestApiId: !Ref TakeNotesApi
+            Auth:
+              Authorizer: CognitoAuthorizer
   ApiGatewayPushToCloudWatchRole:
     Type: AWS::IAM::Role
     Properties:
       Description: Push logs to CloudWatch logs from API Gateway
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -196,7 +210,75 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/AccessLog-${TakeNotesApi}
       RetentionInDays: 365
+  UserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: false
+      UserPoolName: TakeNotesUsers
+      UsernameAttributes:
+        - email
+      AutoVerifiedAttributes:
+        - email
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 6
+          RequireLowercase: true
+          RequireNumbers: false
+          RequireSymbols: false
+          RequireUppercase: true
+  UserPoolClient:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      UserPoolId: !Ref UserPool
+      GenerateSecret: false
+      AllowedOAuthFlowsUserPoolClient: true
+      AllowedOAuthFlows:
+        - code
+        - implicit
+      CallbackURLs:
+        - http://localhost:3000
+        - http://localhost:8080
+        - https://localhost
+        - !Join
+          - ''
+          - - https://
+            - !GetAtt AmplifyBranch.BranchName
+            - .
+            - !GetAtt AmplifyApp.DefaultDomain
+      SupportedIdentityProviders:
+        - COGNITO
+      AllowedOAuthScopes:
+        - phone
+        - email
+        - openid
+      ExplicitAuthFlows:
+        - USER_PASSWORD_AUTH
+  UserPoolDomain:
+    Type: AWS::Cognito::UserPoolDomain
+    Properties:
+      Domain: !Join
+        - '-'
+        - - !Ref CognitoDomainName
+          - !Ref AWS::StackName
+      UserPoolId: !Ref UserPool
 Outputs:
   TakeNotesFunctionApi:
     Description: API Gateway endpoint URL for Prod stage
     Value: !Sub https://${TakeNotesApi}.execute-api.${AWS::Region}.amazonaws.com/{StageNameParam}
+  CognitoID:
+    Description: The Cognito UserPool ID
+    Value: !Ref UserPool
+  CognitoClientID:
+    Description: The Cognito UserPool Client ID
+    Value: !Ref UserPoolTokenClient
+  CognitoDomainName:
+    Description: The Cognito Hosted UI Domain Name
+    Value: !Join
+      - ''
+      - - !Ref CognitoDomainName
+        - '-'
+        - !Ref AWS::StackName
+        - .auth.
+        - !Ref AWS::Region
+        - .amazoncognito.com

--- a/template.yaml
+++ b/template.yaml
@@ -28,6 +28,9 @@ Parameters:
   StageNameParam:
     Type: String
     Default: test
+  CognitoDomainName:
+    Type: String
+    Default: takenotesapp
 Resources:
   TakeNotesTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
#### Why
Auth was previously removed to remove the difficulty of API testing. The new
cognito setup will re add authorization and also remove difficulty of testing, by
correctly providing the id_token from the Hosted UI which can be accessed on cognito UI.
This id now is able to auth all postman requests.

#### What
Added back cognito user pool, client and domain to template.yaml
Hooked up api and function check authorization at api and event level respectively.