### PR TITLE
Fix notes to note

### DIFF
--- a/takeNotes-src/postNote/app.js
+++ b/takeNotes-src/postNote/app.js
@@ -39,7 +39,7 @@ function isValidRequest(context, event) {
 
 function updateRecord(recordId, eventBody, id) {
   let d = new Date();
-  console.log("record id: " + recordId + " eventBody: " + eventBody.note);
+  console.log("record id: ", recordId, " eventBody: ", eventBody.note);
   let noteBody = eventBody.note;
 
   const metaFields = {
@@ -63,14 +63,13 @@ function updateRecord(recordId, eventBody, id) {
     ConditionExpression: "attribute_not_exists(docBody.notes.#noteId)",
     ReturnValues: "ALL_NEW",
   };
-  console.log("params: " + params);
+  console.log("params: ", params);
   return docClient.update(params);
 }
 
 // Lambda Handler
 exports.postNote = async (event, context, callback) => {
-  console.log("event: " + event);
-  console.log("body: " + event.body);
+  console.log("event: ", event);
   if (!isValidRequest(context, event)) {
     return response(400, { message: "Error: Invalid request" });
   }

--- a/takeNotes-src/postNote/app.js
+++ b/takeNotes-src/postNote/app.js
@@ -32,14 +32,14 @@ function isValidRequest(context, event) {
     event.pathParameters.id !== null;
 
   let body = event.body;
-  let isBodyValid = body !== null && body.notes !== null;
+  let isBodyValid = body !== null && body.note !== null;
 
   return isIdValid && isBodyValid;
 }
 
 function updateRecord(recordId, eventBody, id) {
   let d = new Date();
-  console.log("record id: " + recordId + " eventBody: " + eventBody.notes);
+  console.log("record id: " + recordId + " eventBody: " + eventBody.note);
   let noteBody = eventBody.note;
 
   const metaFields = {

--- a/takeNotes-src/putNotes/app.js
+++ b/takeNotes-src/putNotes/app.js
@@ -39,7 +39,7 @@ function isValidRequest(context, event) {
 
 function updateRecord(recordId, eventBody, noteIdx) {
   let d = new Date();
-  console.log("record id: " + recordId + " eventBody: " + eventBody.notes);
+  console.log("record id: ", recordId, " eventBody: ", eventBody.note);
   const params = {
     TableName: TABLE_NAME,
     Key: {
@@ -49,12 +49,12 @@ function updateRecord(recordId, eventBody, noteIdx) {
     ExpressionAttributeNames: { "#noteId": noteIdx },
     ExpressionAttributeValues: {
       ":u": d.toISOString(),
-      ":n": eventBody.notes,
+      ":n": eventBody.note,
     },
     ConditionExpression: "attribute_exists(docBody.notes.#noteId)",
     ReturnValues: "ALL_NEW",
   };
-  console.log("params: " + params);
+  console.log("params: ", params);
   return docClient.update(params);
 }
 

--- a/takeNotes-src/putNotes/app.js
+++ b/takeNotes-src/putNotes/app.js
@@ -60,8 +60,8 @@ function updateRecord(recordId, eventBody, noteIdx) {
 
 // Lambda Handler
 exports.putNotes = async (event, context, callback) => {
-  console.log("event: " + event);
-  console.log("body: " + event.body);
+  console.log("event: ", event);
+  console.log("body: ", event.body);
   if (!isValidRequest(context, event)) {
     return response(400, { message: "Error: Invalid request" });
   }


### PR DESCRIPTION
#### Why
Notes currently should be singular for post and puts -> since it is one 'note', also our front end sends it as note. Also current logging produces 'mssg: [Object object]' which is useless.

#### What
Updated logging for puts and post.
Updated notes to note in eventbody.